### PR TITLE
Use coordinates in algorithm

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -17,6 +17,7 @@ import collections
 import copy
 import importlib
 import numbers
+from re import S
 import sys
 import types
 import warnings
@@ -1110,9 +1111,7 @@ class Alignment:
         return sequences, coordinates
 
     @classmethod
-    def from_pairwise_alignments(
-        cls, pwas: Iterable["Alignment"]
-    ) -> "Alignment":
+    def from_pairwise_alignments(cls, pwas: Iterable["Alignment"]) -> "Alignment":
         """Create an Alignment from a list of pairwise alignments.
 
         This method combines multiple pairwise alignments into
@@ -1219,6 +1218,27 @@ class Alignment:
                         paired_strings[j][1] = sequence[:i] + "-" + sequence[i:]
 
             i += 1
+
+        all_indices = [pwa.indices for pwa in pwas]
+        i = 0
+        while any(ind.shape[1] > i for ind in all_indices):
+            if any(ind.shape[1] > i and ind[0, i] == -1 for ind in all_indices):
+                for j, ind in enumerate(all_indices):
+                    if ind.shape[1] > i and ind[0, i] != -1:
+                        all_indices[j] = np.insert(ind, i, -1, axis=1)
+            i += 1
+
+        # Concatenate all indices vertically
+        all_indices = np.concatenate(
+            [all_indices[0], *[ind[1:] for ind in all_indices[1:]]], axis=0
+        )
+        # Convert indices to coordinates
+        lines = []
+        for i in range(all_indices.shape[0]):
+            lines.append("".join("N" if v != -1 else "-" for v in all_indices[i, :]))
+        coordinates = Alignment.infer_coordinates(lines)
+        sequences = pwas[0].sequences + sum([pwa.sequences[1:] for pwa in pwas[1:]], [])
+        return cls(sequences, coordinates)
 
         # Build output strings
         output_string_seqs = [paired_strings[0][0]] + [seq for _, seq in paired_strings]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -48,6 +48,7 @@ from Bio.Seq import Seq
 from Bio.Seq import translate
 from Bio.Seq import UndefinedSequenceError
 from Bio.Seq import SequenceDataAbstractBaseClass
+from Bio.Seq import _UndefinedSequenceData
 from Bio.SeqRecord import _RestrictedDict
 from Bio.SeqRecord import SeqRecord
 
@@ -1187,6 +1188,34 @@ class Alignment:
 
         if len(pwas) == 0:
             raise ValueError("No pairwise alignments provided.")
+
+        # Validate that all pairwise alignments share the same reference
+        first_seqs = [pwa.sequences[0] for pwa in pwas]
+        # Same length (all types of references)
+        if not all(len(first_seq) == len(first_seqs[0]) for first_seq in first_seqs):
+            raise ValueError("All reference sequences must have the same length.")
+
+        # Same sequence (defined sequences only)
+        string_first_seqs = []
+        for first_seq in first_seqs:
+            # Exclude undefined sequences
+            if isinstance(first_seq, Seq) and isinstance(
+                first_seq._data, _UndefinedSequenceData
+            ):
+                continue
+            elif isinstance(first_seq, SeqRecord) and (
+                first_seq.seq is None
+                or isinstance(first_seq.seq._data, _UndefinedSequenceData)
+            ):
+                continue
+            elif isinstance(first_seq, SeqRecord):
+                string_first_seqs.append(str(first_seq.seq).upper())
+            else:
+                string_first_seqs.append(str(first_seq).upper())
+
+        ungapped_templates = {t.replace("-", "") for t in string_first_seqs}
+        if len(ungapped_templates) > 1:
+            raise ValueError("All reference sequences must match (excluding gaps).")
 
         all_indices = [pwa.indices for pwa in pwas]
         i = 0

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -17,7 +17,6 @@ import collections
 import copy
 import importlib
 import numbers
-from re import S
 import sys
 import types
 import warnings
@@ -1111,7 +1110,9 @@ class Alignment:
         return sequences, coordinates
 
     @classmethod
-    def from_pairwise_alignments(cls, pwas: Iterable["Alignment"]) -> "Alignment":
+    def from_pairwise_alignments(
+        cls, pwas: list["Alignment"] | tuple["Alignment"]
+    ) -> "Alignment":
         """Create an Alignment from a list of pairwise alignments.
 
         This method combines multiple pairwise alignments into
@@ -1119,7 +1120,7 @@ class Alignment:
         reference sequence (ignoring gaps).
 
         Args:
-            pwas: An iterable of Alignment objects representing pairwise alignments.
+            pwas: A list or tuple of Alignment objects representing pairwise alignments.
 
         Returns:
             An Alignment object representing a multiple sequence alignment.
@@ -1187,38 +1188,6 @@ class Alignment:
         if len(pwas) == 0:
             raise ValueError("No pairwise alignments provided.")
 
-        # Extract aligned strings and normalize case
-        original_records = []
-        string_seqs = []
-        for pwa in pwas:
-            if len(pwa.sequences) != 2:
-                raise ValueError("Expected exactly 2 sequences per alignment.")
-            original_records.extend(pwa.sequences)
-            string_seqs.extend([seq_str.upper() for seq_str in pwa])
-
-        # Validate that all pairwise alignments share the same ungapped reference
-        ungapped_templates = {t.replace("-", "") for t in string_seqs[::2]}
-        if len(ungapped_templates) != 1:
-            raise ValueError("All reference sequences must match (excluding gaps).")
-
-        # Group in pairs
-        paired_strings = [string_seqs[i : i + 2] for i in range(0, len(string_seqs), 2)]
-
-        # Gap synchronzation across templates
-        i = 0
-        while any(len(template) > i for template, _ in paired_strings):
-            if any(template[i] == "-" for template, _ in paired_strings):
-                for j, (template, sequence) in enumerate(paired_strings):
-
-                    # If the template has no gap at position i,
-                    # Insert '-' in both template and sequence at position i
-                    # to maintain alignment with other templates
-                    if len(template) > i and template[i] != "-":
-                        paired_strings[j][0] = template[:i] + "-" + template[i:]
-                        paired_strings[j][1] = sequence[:i] + "-" + sequence[i:]
-
-            i += 1
-
         all_indices = [pwa.indices for pwa in pwas]
         i = 0
         while any(ind.shape[1] > i for ind in all_indices):
@@ -1239,40 +1208,6 @@ class Alignment:
         coordinates = Alignment.infer_coordinates(lines)
         sequences = pwas[0].sequences + sum([pwa.sequences[1:] for pwa in pwas[1:]], [])
         return cls(sequences, coordinates)
-
-        # Build output strings
-        output_string_seqs = [paired_strings[0][0]] + [seq for _, seq in paired_strings]
-
-        # Fill the potential gap at the end
-        max_lenth = max(len(seq) for seq in output_string_seqs)
-        output_string_seqs = [
-            seq + "-" * (max_lenth - len(seq)) for seq in output_string_seqs
-        ]
-
-        # Infer coordinates using parse_printed_alignment
-        output_string_seqs_bytes = [s.encode() for s in output_string_seqs]
-        _, coordinates = cls.parse_printed_alignment(output_string_seqs_bytes)
-        coordinates = np.array(coordinates, np.intp)
-
-        # Extract ungapped sequences
-        ungapped_sequences = [seq.replace("-", "") for seq in output_string_seqs]
-
-        # Create records with ungapped sequences
-        records = []
-        for i, original_seq in enumerate(original_records[:1] + original_records[1::2]):
-            if isinstance(original_seq, SeqRecord):
-                new_record = SeqRecord(
-                    Seq(ungapped_sequences[i]),
-                    id=original_seq.id,
-                    description=original_seq.description,
-                    dbxrefs=original_seq.dbxrefs,
-                )
-            else:
-                id_value = "reference" if i == 0 else f"seq_{i}"
-                new_record = SeqRecord(Seq(ungapped_sequences[i]), id=id_value)
-            records.append(new_record)
-
-        return cls(records, coordinates)
 
     def __init__(self, sequences, coordinates=None):
         """Initialize a new Alignment object.

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -33,6 +33,7 @@ from Bio.Align import MultipleSeqAlignment
 from Bio.Align import PairwiseAligner
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+import numpy as np
 
 
 class TestBasics(unittest.TestCase):
@@ -968,6 +969,14 @@ class TestFromPairwiseAlignments(unittest.TestCase):
         self.assertEqual(str(msa[1]), "ACGGT")
         self.assertEqual(str(msa[2]), "A---T")
 
+        # Works with undefined sequences
+        pwa1_undefined = Alignment([Seq(None, 4), Seq(None, 5)], pwa1.coordinates)
+        pwa2_undefined = Alignment([Seq(None, 4), Seq(None, 2)], pwa2.coordinates)
+        msa_undefined = Alignment.from_pairwise_alignments(
+            [pwa1_undefined, pwa2_undefined]
+        )
+        self.assertTrue((msa_undefined.coordinates == msa.coordinates).all())
+
     def test_metadata_preservation(self):
         """Test that sequence metadata (IDs and descriptions) are preserved in the Alignment.
 
@@ -1003,11 +1012,25 @@ class TestFromPairwiseAlignments(unittest.TestCase):
     def test_mismatched_references(self):
         """Test that mismatched reference sequences raise a ValueError."""
         aligner = PairwiseAligner()
-        pwa1 = next(aligner.align("ACGT", "ACGGT"))
+        pwa1 = next(aligner.align("ACGAAAT", "ACGGT"))
         pwa2 = next(aligner.align("ACCT", "AT"))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as context:
             Alignment.from_pairwise_alignments([pwa1, pwa2])
+        self.assertIn("All reference sequences must", str(context.exception))
+
+        # Works with undefined sequences
+        pwa1_undefined = Alignment([Seq(None, 7), Seq(None, 5)], pwa1.coordinates)
+        pwa2_undefined = Alignment([Seq(None, 4), Seq(None, 2)], pwa2.coordinates)
+        with self.assertRaises(ValueError) as context:
+            Alignment.from_pairwise_alignments([pwa1_undefined, pwa2_undefined])
+        self.assertIn("All reference sequences must", str(context.exception))
+
+        # Works with mix
+        pwa1_undefined = Alignment([Seq(None, 7), Seq(None, 5)], pwa1.coordinates)
+        with self.assertRaises(ValueError) as context:
+            Alignment.from_pairwise_alignments([pwa1_undefined, pwa2])
+        self.assertIn("All reference sequences must", str(context.exception))
 
     def test_empty_input(self):
         """Test that empty input raises a ValueError."""

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -944,14 +944,6 @@ class TestFromPairwiseAlignments(unittest.TestCase):
         self.assertEqual(str(msa[1]), "ACGGT")
         self.assertEqual(str(msa[2]), "A---T")
 
-        # Validate metadata
-        self.assertEqual(msa.sequences[0].id, "reference")
-        self.assertEqual(msa.sequences[1].id, "seq_1")
-        self.assertEqual(msa.sequences[2].id, "seq_2")
-        self.assertEqual(msa.sequences[0].description, "<unknown description>")
-        self.assertEqual(msa.sequences[1].description, "<unknown description>")
-        self.assertEqual(msa.sequences[2].description, "<unknown description>")
-
     def test_pwas_built_with_seqs(self):
         """Test that from_pairwise_alignments works with pairwise alignments built with Seq objects."""
         aligner = PairwiseAligner()
@@ -976,14 +968,6 @@ class TestFromPairwiseAlignments(unittest.TestCase):
         self.assertEqual(str(msa[1]), "ACGGT")
         self.assertEqual(str(msa[2]), "A---T")
 
-        # Validate metadata
-        self.assertEqual(msa.sequences[0].id, "reference")
-        self.assertEqual(msa.sequences[1].id, "seq_1")
-        self.assertEqual(msa.sequences[2].id, "seq_2")
-        self.assertEqual(msa.sequences[0].description, "<unknown description>")
-        self.assertEqual(msa.sequences[1].description, "<unknown description>")
-        self.assertEqual(msa.sequences[2].description, "<unknown description>")
-
     def test_metadata_preservation(self):
         """Test that sequence metadata (IDs and descriptions) are preserved in the Alignment.
 
@@ -1003,7 +987,7 @@ class TestFromPairwiseAlignments(unittest.TestCase):
 
         # Use the method being tested
         msa = Alignment.from_pairwise_alignments([pwa1, pwa2])
-        
+
         # Validate that from_pairwise_alignments gives the right msa
         self.assertEqual(str(msa[0]), "ACG-T")
         self.assertEqual(str(msa[1]), "ACGGT")
@@ -1038,9 +1022,7 @@ class TestFromPairwiseAlignments(unittest.TestCase):
         not_pairwsise_alignment = Alignment(["ACGT-", "ACGTT", "A---T"])
 
         with self.assertRaises(ValueError):
-            Alignment.from_pairwise_alignments(
-                [pwa, not_pairwsise_alignment]
-            )
+            Alignment.from_pairwise_alignments([pwa, not_pairwsise_alignment])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi @Cassiebastress, below is a modified version of the algorithm that used coordinates, and would work for undefined sequences as requested by the biopython's maintainers. Please have a look and let me know if you notice something wrong or weird.

I was thinking, there is no need to restrict this function to pairwise alignments. As long as two alignments have the same reference, it should be possible to combine them using this. What do you think? That would require renaming the function and changing the docs here and there, but I think it would be better.